### PR TITLE
Targets tweaks

### DIFF
--- a/MinVer.Cli/MinVer.targets
+++ b/MinVer.Cli/MinVer.targets
@@ -1,4 +1,4 @@
-<Project>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
     <MinVerVersion Condition=" '$(MinVerVersion)' == '' ">$(MINVER_VERSION)</MinVerVersion>

--- a/MinVer.Cli/MinVer.targets
+++ b/MinVer.Cli/MinVer.targets
@@ -1,6 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
+    <GetPackageVersionDependsOn>$(GetPackageVersionDependsOn);MinVer</GetPackageVersionDependsOn>
     <MinVerVersion Condition=" '$(MinVerVersion)' == '' ">$(MINVER_VERSION)</MinVerVersion>
     <MinVerBuildMetadata Condition=" '$(MinVerBuildMetadata)' == '' ">$(MINVER_BUILD_METADATA)</MinVerBuildMetadata>
   </PropertyGroup>

--- a/MinVer.Cli/buildMultiTargeting/MinVer.targets
+++ b/MinVer.Cli/buildMultiTargeting/MinVer.targets
@@ -1,3 +1,3 @@
-﻿<Project>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="../build/MinVer.targets" />
 </Project>


### PR DESCRIPTION
This make a couple small changes to the targets files:

- Adding the xml namespace means that these targets files can be properly imported if someone tries to use VS 2015. If you don't care about this, or actively want to prevent it, I can remove this commit.
- The GetPackageVersionDependsOn property needs to be set so that when a project reference is used to create a package dependency, the generated nuspec has the correct version for the project reference.

<!-- connects to #3 -->