### PR TITLE
Get version from console output without writing to file

### DIFF
--- a/MinVer/MinVer.targets
+++ b/MinVer/MinVer.targets
@@ -7,14 +7,15 @@
   </PropertyGroup>
 
   <Target Name="MinVer_GetVersion" Condition=" '$(MinVerVersion)' == '' ">
+    <Exec Command="dotnet &quot;$(MSBuildThisFileDirectory)MinVer.Cli.dll&quot; &quot;$(MSBuildProjectDirectory)&quot;" ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" ItemName="MinVerConsoleOutputItems" />
+    </Exec>
+    <ItemGroup>
+      <MinVerConsoleOutputVersion Include="@(MinVerConsoleOutputItems)" Condition="'$([System.String]::new(`%(Identity)`).StartsWith(`MinVer:`))' != 'true'" />
+    </ItemGroup>
     <PropertyGroup>
-      <OutputFile>$(IntermediateOutputPath)min-ver-$([System.Guid]::NewGuid().ToString().Substring(0, 5)).txt</OutputFile>
+      <MinVerVersion>@(MinVerConsoleOutputVersion)</MinVerVersion>
     </PropertyGroup>
-    <Exec Command="dotnet &quot;$(MSBuildThisFileDirectory)MinVer.Cli.dll&quot; &quot;$(MSBuildProjectDirectory)&quot; &gt; &quot;$(OutputFile)&quot;" />
-    <PropertyGroup>
-      <MinVerVersion>$([System.IO.File]::ReadAllText($(OutputFile)).Trim())</MinVerVersion>
-    </PropertyGroup>
-    <Delete Files="$(OutputFile)"/>
   </Target>
 
   <Target Name="MinVer" BeforeTargets="CoreCompile;GenerateNuspec" DependsOnTargets="MinVer_GetVersion">


### PR DESCRIPTION
This removes the hack of writing/reading from a file to get the version from the output.

Instead, each line of the output is checked to see if it starts with `MinVer:`, which all of the log lines will have.

If a line doesn't have that, then it is assumed the line contains the version, and that value will be used in the `MinVerVersion` property. 