### PR TITLE
suppress MinVer for non-SDK projects and print warning

### DIFF
--- a/MinVer/MinVer.csproj
+++ b/MinVer/MinVer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>Minimalistic versioning for .NET projects.</Description>
+    <Description>Minimalistic versioning for .NET SDK-style projects.</Description>
     <DevelopmentDependency>true</DevelopmentDependency>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <LangVersion>latest</LangVersion>

--- a/MinVer/MinVer.targets
+++ b/MinVer/MinVer.targets
@@ -21,12 +21,16 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="MinVer" BeforeTargets="CoreCompile;GenerateNuspec" DependsOnTargets="MinVer_GetVersion" Condition="'$(DesignTimeBuild)' != 'true'">
+  <Target Name="MinVer" BeforeTargets="CoreCompile;GenerateNuspec" DependsOnTargets="MinVer_GetVersion" Condition="'$(UsingMicrosoftNETSdk)' == 'true' And '$(DesignTimeBuild)' != 'true'">
     <PropertyGroup>
       <MinVerVersion Condition=" '$(MinVerBuildMetadata)' != '' ">$(MinVerVersion)+$(MinVerBuildMetadata)</MinVerVersion>
       <Version>$(MinVerVersion)</Version>
       <PackageVersion>$(MinVerVersion)</PackageVersion>
     </PropertyGroup>
+  </Target>
+
+  <Target Name="MinVer_Warnings" BeforeTargets="MinVer" Condition="'$(DesignTimeBuild)' != 'true'">
+    <Error Condition="'$(UsingMicrosoftNETSdk)' != 'true'" Code="MINVER0002" Text="MinVer only works in SDK-style projects." />
   </Target>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 _[![nuget](https://img.shields.io/nuget/v/MinVer.svg?style=flat)](https://www.nuget.org/packages/MinVer)_
 _[![Build status](https://ci.appveyor.com/api/projects/status/0ai8j3x4tg6w3ima/branch/master?svg=true)](https://ci.appveyor.com/project/adamralph/min-ver/branch/master)_
 
-A minimalistic [.NET package](https://www.nuget.org/packages/MinVer) for versioning .NET projects using Git tags.
+A minimalistic [.NET package](https://www.nuget.org/packages/MinVer) for versioning .NET SDK-style projects using Git tags.
 
 ## Prerequisites
 
-- [.NET Core SDK](https://www.microsoft.com/net/download)
+- [.NET Core SDK 2.1.300 or later](https://www.microsoft.com/net/download)
 - [libcurl](https://curl.haxx.se/libcurl/) (Linux only)
 
 ## Quick start


### PR DESCRIPTION
Fixes #59.

Connects to #3.